### PR TITLE
 Fixed NPE on ControlPoint.start() when default SSDP port is already

### DIFF
--- a/core/src/main/java/org/cybergarage/upnp/ssdp/HTTPUSocket.java
+++ b/core/src/main/java/org/cybergarage/upnp/ssdp/HTTPUSocket.java
@@ -23,6 +23,7 @@
 
 package org.cybergarage.upnp.ssdp;
 
+import java.net.BindException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
@@ -53,7 +54,7 @@ public class HTTPUSocket
 		open();
 	}
 	
-	public HTTPUSocket(String bindAddr, int bindPort)
+	public HTTPUSocket(String bindAddr, int bindPort) throws BindException
 	{
 		open(bindAddr, bindPort);
 	}
@@ -114,7 +115,7 @@ public class HTTPUSocket
 		return true;
 	}
 	
-	public boolean open(String bindAddr, int bindPort)
+	public boolean open(String bindAddr, int bindPort) throws BindException
 	{
 		close();
 		
@@ -123,10 +124,14 @@ public class HTTPUSocket
 			InetSocketAddress bindInetAddr = new InetSocketAddress(InetAddress.getByName(bindAddr), bindPort);
 			ssdpUniSock = new DatagramSocket(bindInetAddr);
 		}
-		catch (Exception e) {
-			Debug.warning(e);
-			return false;
-		}
+        catch (BindException possible) {
+            Debug.warning(possible);
+            throw possible;
+        }
+        catch (Exception e) {
+            Debug.warning(e);
+            return false;
+        }
 
 		/*
 		try {

--- a/core/src/main/java/org/cybergarage/upnp/ssdp/SSDPSearchResponseSocket.java
+++ b/core/src/main/java/org/cybergarage/upnp/ssdp/SSDPSearchResponseSocket.java
@@ -19,6 +19,7 @@
 
 package org.cybergarage.upnp.ssdp;
 
+import java.net.BindException;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
 
@@ -35,7 +36,7 @@ public class SSDPSearchResponseSocket extends HTTPUSocket implements Runnable
 		setControlPoint(null);
 	}
 	
-	public SSDPSearchResponseSocket(String bindAddr, int port)
+	public SSDPSearchResponseSocket(String bindAddr, int port) throws BindException
 	{
 		super(bindAddr, port);
 		setControlPoint(null);


### PR DESCRIPTION
The intention of the original code is to search for an available port by temporarily binding to it. The bug is in ignoring the failure signal (boolean return value).
