### PR TITLE
send http packet at one time to fix TP-LINK TL-WAR450L bug

### DIFF
--- a/core/src/main/java/org/cybergarage/http/HTTPRequest.java
+++ b/core/src/main/java/org/cybergarage/http/HTTPRequest.java
@@ -409,8 +409,11 @@ public class HTTPRequest extends HTTPPacket
 
 			out = postSocket.getOutputStream();
 			PrintStream pout = new PrintStream(out);
-			pout.print(getHeader());
-			pout.print(HTTP.CRLF);
+			String httpPacket = ""; // send at one time to fix TP-LINK TL-WAR450L bug, cm++, 2018-8-1
+            httpPacket += getHeader(); // cm++, 2018-8-1
+            httpPacket += HTTP.CRLF; // cm++, 2018-8-1
+//			pout.print(getHeader());
+//			pout.print(HTTP.CRLF);
 			
 			boolean isChunkedRequest = isChunked();
 			
@@ -423,19 +426,26 @@ public class HTTPRequest extends HTTPPacket
 				if (isChunkedRequest == true) {
 					// Thanks for Lee Peik Feng <pflee@users.sourceforge.net> (07/07/05)
 					String chunSizeBuf = Long.toHexString(contentLength);
-					pout.print(chunSizeBuf);
-					pout.print(HTTP.CRLF);
+                    httpPacket += chunSizeBuf; // cm++, 2018-8-1
+                    httpPacket += HTTP.CRLF; // cm++, 2018-8-1
+//					pout.print(chunSizeBuf);
+//					pout.print(HTTP.CRLF);
 				}
-				pout.print(content);
+                httpPacket += content; // cm++, 2018-8-1
+				//pout.print(content);
 				if (isChunkedRequest == true)
-					pout.print(HTTP.CRLF);
+                    httpPacket += HTTP.CRLF; // cm++, 2018-8-1
+					//pout.print(HTTP.CRLF);
 			}
 
 			if (isChunkedRequest == true) {
-				pout.print("0");
-				pout.print(HTTP.CRLF);
+                httpPacket += "0"; // cm++, 2018-8-1
+                httpPacket += HTTP.CRLF; // cm++, 2018-8-1
+//				pout.print("0");
+//				pout.print(HTTP.CRLF);
 			}
-			
+
+			pout.print(httpPacket); // cm++, 2018-8-1
 			pout.flush();
 
 			in = postSocket.getInputStream();


### PR DESCRIPTION
Hello, dear skonno:
	I'm using cybergarage-upnp on android development ( Android Studio 3.1.3,  gradle 4.4, target API 27, JDK 1.8). I download the source from https://github.com/cybergarage/cybergarage-upnp. Now I can find my router on my Android App by cybergarage-upnp, but when I try to add port mapping, it reports '411 Length required', like this:
This is what I sended: -------------------------------------------------------------------------------------------
```
POST /ipc HTTP/1.0
Content-Type: text/xml; charset="utf-8"
HOST: 192.168.1.1:1900
Content-Length: 700
SOAPACTION: "urn:schemas-upnp-org:service:WANIPConnection:1#AddPortMapping"

<?xml version="1.0" encoding="utf-8"?>
<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
   <s:Body>
      <u:AddPortMapping xmlns:u="urn:schemas-upnp-org:service:WANIPConnection:1">
         <NewRemoteHost></NewRemoteHost>
         <NewExternalPort>80</NewExternalPort>
         <NewProtocol>TCP</NewProtocol>
         <NewInternalPort>2222</NewInternalPort>
         <NewInternalClient>192.168.1.198</NewInternalClient>
         <NewEnabled>1</NewEnabled>
         <NewPortMappingDescription>forward rule 1</NewPortMappingDescription>
         <NewLeaseDuration>0</NewLeaseDuration>
      </u:AddPortMapping>
   </s:Body>
</s:Envelope>
````

This is what I received: -------------------------------------------------------------------------
```
HTTP/1.1 411 
Content-Type: text/xml; charset="utf-8"
Server: TP-LINK SMB TL-WAR450L, UPnP/1.0
Content-Length: 54

<html><body><h1>411 Length Required</h1></body></html>
```
----------------------------------------------------------------------------------------------------------

Can you help me? Thanks!
